### PR TITLE
fix: nprime example remove drop

### DIFF
--- a/examples/nprime.masm
+++ b/examples/nprime.masm
@@ -11,7 +11,6 @@ proc.append
 
     # [prime, i, n, primes..]
     mem_store
-    drop
 
     # [i++, n, primes..]
     swap.2


### PR DESCRIPTION
The nprime example was broken, and this is a fix. Fixes https://github.com/0xPolygonMiden/examples/issues/24

It was already fixed on Miden main 8 days ago in here https://github.com/maticnetwork/miden/commit/7dd466c2649c21f7eb2ce96f1206ff753272ac5a

Somehow we should avoid maintaining this file in two places.