### PR TITLE
feat: Proving for the playground

### DIFF
--- a/playground/miden-wasm/Cargo.toml
+++ b/playground/miden-wasm/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 console_error_panic_hook = { console_error_panic_hook = "0.1.7" }
-miden = "0.3"
+miden = {version = "0.3", default-features = false }
 serde = { version = "1", features = ["derive"] } # You only need this if you want app persistence
 serde_json = "1.0.48"
 wasm-bindgen = "0.2.78"

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "miden-assembly-examples-playground",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@codemirror/theme-one-dark": "^6.1.0",

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { eclipse } from "@uiw/codemirror-theme-eclipse";
-import init, { program } from "miden-wasm";
+import init, { run_program, prove_program } from "miden-wasm";
 import MidenLogo from "./components/MidenLogo";
 import Link from "./components/Link";
 
@@ -74,23 +74,47 @@ end`
 
   /**
   * This runs the program using the MidenVM and displays the output.
-  * It rund the Rust program that is imported above.
+  * It runs the Rust program that is imported above.
   */ 
 
   const runProgram = async () => {
     init().then(() => {
       try {
-        const resp = program(code, inputs, numOfOutputs);
+        const resp = run_program(code, inputs, numOfOutputs);
         console.log(resp.toString());
-        setOutput(`Miden VM Program Output \nStack = [${resp.toString()}] \nCycles = <need to return cycles> \n`);
+        setOutput(`Miden VM Program Output
+Stack = [${resp.toString()}]
+Cycles = <available with Miden VM v0.4>`);
       } catch (error) {
         setOutput("Error: Check the developer console for details.");
       }
         })};
   
+
+  /**
+  * This proves the program using the MidenVM and displays the output.
+  * It runs the Rust program that is imported above.
+  */ 
+
+    const proveProgram = async () => {
+      init().then(() => {
+        try {
+          const resp = prove_program(code, inputs, numOfOutputs);
+          console.log(resp.toString());
+          const stack_output = resp.slice(0, numOfOutputs);
+          const overflow_addrs = resp.slice(numOfOutputs, resp.length);
+          setOutput(`Miden VM Program Output
+Stack = [${stack_output.toString()}]
+Overflow Address = [${overflow_addrs.toString()}]
+Cycles = <available with Miden VM v0.4>`);
+        } catch (error) {
+          setOutput("Error: Check the developer console for details.");
+        }
+          })};
+    
   /**
   * We need to add the following:
-  * Prove, Verify, and Debug as functions that can be called.
+  * Verify, and Debug as functions that can be called.
   */ 
 
   return (
@@ -115,7 +139,7 @@ end`
             <DropDown onExampleValueChange={handleSelectChange}/>
             <ActionButton label="Run" onClick={runProgram} />
             <ActionButton label="Debug" /> 
-            <ActionButton label="Prove" />
+            <ActionButton label="Prove" onClick={proveProgram} />
             <ActionButton label="Verify" />
 
         </div>


### PR DESCRIPTION
Closes #19 

This PR enables proving to the playground. 

There are some open questions regarding the UX and the proving step code itself:

- UX
- - At the moment, for the user running and proving a program looks equal. The output is almost the same. 
- - We should add some info that proving might take a while (see Game of Life example), maybe even a pop-up that prints something during the proof
- - There is no way to show the proof atm

- Proving step
- - We don't expose in Miden v0.3 any info about the trace length or cycles or even time to prove in `ProgramOutputs` or `ExecutionTrace`, so we can't get the numbers (maybe I am mistaken, but I didn't find it)
- - I couldn't find a way to pass the proof from Rust to Typescript (frontend) via wasm-bindgen. There seems to be a way to return complex structures from Rust to Typescript (frontend) but I didn't understand exactly how