### PR TITLE
refactor: update hash instruction in shamir example (Merge once miden v0.4 released)

### DIFF
--- a/examples/shamir-secret-share.masm
+++ b/examples/shamir-secret-share.masm
@@ -30,7 +30,7 @@ proc.gen_secret_com
     # input: [secret, rand]
     padw
     push.0.0      #[0, 0, 0, 0, 0, 0, secret, rand]
-    rphash        #[com_3, com_2, com_1, com_0]
+    hmerge        #[com_3, com_2, com_1, com_0]
 end
 
 # create k-1 random polynomial coefficients
@@ -43,7 +43,7 @@ proc.gen_poly_coeffs
     padw    #[0, 0, 0, 0, rand, k]
     padw    #[0, 0, 0, 0, 0, 0, 0, 0, rand, k]
     drop    #[0, 0, 0, 0, 0, 0, 0, rand, k]
-    rphash  #[coef_4, coef_3, coef_2, coef_1, k]
+    hmerge  #[coef_4, coef_3, coef_2, coef_1, k]
 
     # introduce counter and evaluate if we have enough coefficients
     # counter is initialized to 5 as we must account for the secret which acts as the intercept
@@ -60,7 +60,7 @@ proc.gen_poly_coeffs
         movdn.5
         dupw       #[coef_4, coef_3, coef_2, coef_1, coef_4, coef_3, coef_2, coef_1, k, counter, ...]
         padw       #[0, 0, 0, 0, coef_4, coef_3, coef_2, coef_1, coef_4, coef_3, coef_2, coef_1, k, counter]
-        rphash     #[coef_8, coef_7, coef_6, coef_5, coef_4, coef_3, coef_2, coef_1, k, counter, ...]
+        hmerge     #[coef_8, coef_7, coef_6, coef_5, coef_4, coef_3, coef_2, coef_1, k, counter, ...]
 
         # evaluate if we have enough coefficients
         movup.9


### PR DESCRIPTION
This PR updates the Shamir example such that it will be compatible with the miden v0.4.  In miden assembly v0.4 the `rphash` instruction has changed to `hmerge`.  This PR has modified the shamir example to accommodate for this change.   We should merge this PR once Miden v0.4 has been released (hopefully next week).