### PR TITLE
add "developer tools" link to navigation

### DIFF
--- a/playground/src/components/Header.tsx
+++ b/playground/src/components/Header.tsx
@@ -7,7 +7,7 @@ import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 /** External links for the top navigation menu */
 const navigation = [
     { name: 'Documentation', href: 'https://wiki.polygon.technology/docs/miden/user_docs/assembly/main' },
-    { name: 'Examples', href: 'https://github.com/0xPolygonMiden/examples#available-examples' },
+    { name: 'Developer Tools', href: 'https://0xpolygonmiden.github.io/miden-vm/intro/usage/main.html' },
     { name: 'Homepage', href: 'https://polygon.technology/solutions/polygon-miden/' },
 ]
 


### PR DESCRIPTION
I replaced the "examples" link with a link to the main usage page in the Miden VM docs, which now has information about the different developer tools and resources available.