### PR TITLE
Change `overflow_addrs` to being optional

### DIFF
--- a/playground/src/utils/helper_functions.tsx
+++ b/playground/src/utils/helper_functions.tsx
@@ -158,7 +158,7 @@ export const checkInputs = (
 
 const outputSchema = yup.object().shape({
   stack_output: yup.array().of(yup.number().integer().min(0)).required(),
-  overflow_addrs: yup.array().of(yup.number().integer().min(0)).required(),
+  overflow_addrs: yup.array().of(yup.number().integer().min(0)).notRequired(),
   trace_len: yup.number().integer().min(0).optional(),
 });
 


### PR DESCRIPTION
`overflow_addrs` should be `notRequired()` as we do not always need it to verify a proof.  This PR modifies the `yup` schema to reflect this.  This impacts proof verification and can be recreated using the `advice_provider` example.