### PR TITLE
feat: adding the breakpoint for debugging

### DIFF
--- a/playground/miden-wasm/src/lib.rs
+++ b/playground/miden-wasm/src/lib.rs
@@ -289,6 +289,27 @@ fn test_debug_program() {
         vec![3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     );
     assert_eq!(output.memory, Vec::<u64>::new());
+
+    let mut debug_executor_with_breakpoint = utils_debug::DebugExecutor::new(
+        "begin
+            push.1 push.2 breakpoint add
+        end",
+        "",
+    )
+    .unwrap();
+    let output = debug_executor_with_breakpoint.execute(utils_debug::DebugCommand::PlayAll, None);
+
+    // we test if it plays all the way to the end
+    assert_eq!(output.clk, 5);
+    assert_eq!(output.op, Some("Noop".to_string()));
+    assert_eq!(output.instruction, Some("\"breakpoint\"".to_string()));
+    assert_eq!(output.num_of_operations, Some(0));
+    assert_eq!(output.operation_index, Some(1));
+    assert_eq!(
+        output.stack,
+        vec![2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    );
+    assert_eq!(output.memory, Vec::<u64>::new());
 }
 
 #[test]

--- a/playground/miden-wasm/src/utils_debug.rs
+++ b/playground/miden-wasm/src/utils_debug.rs
@@ -78,6 +78,9 @@ impl DebugExecutor {
             DebugCommand::PlayAll => {
                 while let Some(new_vm_state) = self.next_vm_state() {
                     self.vm_state = new_vm_state;
+                    if self.should_break() {
+                        break;
+                    }
                 }
                 self.vm_state_to_output()
             }
@@ -86,6 +89,9 @@ impl DebugExecutor {
                     match self.next_vm_state() {
                         Some(next_vm_state) => {
                             self.vm_state = next_vm_state;
+                            if self.should_break() {
+                                break;
+                            }
                         }
                         None => break,
                     }
@@ -95,6 +101,9 @@ impl DebugExecutor {
             DebugCommand::RewindAll => {
                 while let Some(new_vm_state) = self.prev_vm_state() {
                     self.vm_state = new_vm_state;
+                    if self.should_break() {
+                        break;
+                    }
                 }
                 self.vm_state_to_output()
             }
@@ -103,6 +112,9 @@ impl DebugExecutor {
                     match self.prev_vm_state() {
                         Some(new_vm_state) => {
                             self.vm_state = new_vm_state;
+                            if self.should_break() {
+                                break;
+                            }
                         }
                         None => break,
                     }
@@ -156,6 +168,15 @@ impl DebugExecutor {
         };
 
         output
+    }
+
+    /// Returns `true` if the current state should break.
+    fn should_break(&self) -> bool {
+        self.vm_state
+            .asmop
+            .as_ref()
+            .map(|asm| asm.should_break())
+            .unwrap_or(false)
     }
 }
 

--- a/playground/src/markdown/Explainer.md
+++ b/playground/src/markdown/Explainer.md
@@ -96,7 +96,7 @@ Want to know more? [Here](https://wiki.polygon.technology/docs/miden/user_docs/a
 You can create a program and run it. There will be no proof generated which is much faster. Every program that successfully executes can also be proven, so I suggest using this functionality when hacking around. 
 
 ### Debug a program
-You can step through the program and see the current VM state displayed in the Output section. 
+You can step through the program and see the current VM state displayed in the Output section. And the best thing is, that you can add `breakpoint` as Miden Assembly instruction, see below for an example. 
 
 ```
 Clock: 2001
@@ -120,6 +120,20 @@ Memory (Addr, Mem): [0]: [2, 0, 0, 0]
 Additional documentation on how the VM executes its operations can be foound at the [Miden VM documentation page](https://0xpolygonmiden.github.io/miden-vm/design/programs.html)
 
 Remember: Miden programs lenghts are expressed in cycles. The Miden VM will round the cycles always to the next power of 2 and has a minimum at 2^10.
+
+
+Example for setting the breakpoint:
+
+Just add `breakpoint` as instruction and the debugger will stop at this particular point. 
+
+```
+begin
+  push.1
+  push.2
+  breakpoint
+  add
+end
+```
 
 ### Prove a program
 This is what makes the Miden VM interesting. Here you can run your program and create a proof for it. The proof is stored in memory in the backend. You can take a look at the proof by clicking "Show Proof".


### PR DESCRIPTION
I am adding the `breakpoint` to the Playground. When the user adds `breakpoint` in the code and runs the debugger, it stops at the breakpoint.