### PR TITLE
Fibonacci example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There are several examples in our repo and we hope we get more in the future. Th
 
 - **Collatz**: A program which executes an unbounded loop to compute a Collatz sequence which starts with the provided value; the output of the program is the number of steps needed to reach 1 - the end of the sequence.
 
-- **Fibonnacci**: Elegant way to calculate the 1000th fibonacci number. 
+- **Fibonnacci**: Elegant way to calculate the 1001st fibonacci number. 
 
 - **nPrime**: Program to calculate the n-th prime number. It will return all prime numbers up to the n-th prime number which is on top of the stack. 
 

--- a/examples/fibonacci.inputs
+++ b/examples/fibonacci.inputs
@@ -1,3 +1,3 @@
 {
-    "operand_stack": ["1", "1"]
+    "operand_stack": ["1"]
 }

--- a/examples/fibonacci.masm
+++ b/examples/fibonacci.masm
@@ -1,4 +1,4 @@
-# Elegant way to calculate the 1000th fibonacci number 
+# Elegant way to calculate the 1001st fibonacci number 
 
 begin
     repeat.1000


### PR DESCRIPTION
Current version of Fibonacci example computes not 1000th, but 1002nd Fibonacci number. 
This PR changes this example to computation of 1001st Fibonacci number by putting only `[1]` to the input. This approach allows to remain `1000` as cycles number, changing only stack and a comment. 