### PR TITLE
Add Discrete Fourier Transform example

### DIFF
--- a/examples/dft.inputs
+++ b/examples/dft.inputs
@@ -1,0 +1,3 @@
+{
+    "operand_stack": ["2"]
+}

--- a/examples/dft.inputs
+++ b/examples/dft.inputs
@@ -1,3 +1,3 @@
 {
-    "operand_stack": ["2"]
+    "operand_stack": ["44", "13", "21", "15", "4"]
 }

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -27,6 +27,56 @@ const.INPUT_ARR_LOC=0
 # Location at 3 * 2^30, the first address "with no special meaning" in the root context
 const.RESULT_ARR_LOC=3221225472
 
+#! Computes log base 2. Only supports {1, 2, 4, 8, 16}.
+#! Input: [n]
+#! Output: [log2(n)] if n is supported, otherwise halts
+proc.log2
+    dup                                        # stack: [n, n]
+    eq.1                                       # stack: [0 or 1, n]
+    if.true
+        # n == 1
+        drop                                   # stack: []
+        push.0                                 # stack: [0]
+    else
+        dup                                    # stack: [n, n]
+        eq.2                                   # stack: [0 or 1, n]
+        if.true
+            # n == 2
+            drop                               # stack: []
+            push.1                             # stack: [1]
+        else
+            dup                                # stack: [n, n]
+            eq.4                               # stack: [0 or 1, n]
+            if.true
+                # n == 4
+                drop                           # stack: []
+                push.2                         # stack: [2]
+            else
+                dup                            # stack: [n, n]
+                eq.8                           # stack: [0 or 1, n]
+                if.true
+                    # n == 8
+                    drop                       # stack: []
+                    push.3                     # stack: [3]
+                else
+                    dup                        # stack: [n, n]
+                    eq.16                      # stack: [0 or 1, n]
+                    if.true
+                        # n == 16
+                        drop                       # stack: []
+                        push.4                     # stack: [4]
+                    else
+                        # n unsupported; halt
+                        push.1
+                        assertz
+                    end
+                end
+            end
+        end
+
+    end
+end
+
 #! Computes the primitive root of unity for a subgroup of size 2^n.
 #!
 #! Input: [n], the size of the input list (must be <= 32)
@@ -65,29 +115,27 @@ proc.f_k.5
     push.1                                     # push 1 to enter the loop
     while.true
         # compute `root_of_unity^(jk)`
-        loc_load.1                             # load root_of_unity
-        loc_load.0                             # load k
-        loc_load.3                             # load j
-        mul                                    # compute j*k
-        exp                                    # compute root_of_unity^(jk)
-        mul                                    # compute v{j} * root_of_unity^(jk)
+        loc_load.1                             # stack: [root_of_unity, v{j}, ..., v{n-1}]
+        loc_load.0                             # stack: [k , root_of_unity, v{j}, ..., v{n-1}]
+        loc_load.3                             # stack: [j, k , root_of_unity, v{j}, ..., v{n-1}]
+        mul                                    # stack: [j*k , root_of_unity, v{j}, ..., v{n-1}]
+        exp                                    # stack: [root_of_unity^(jk), v{j}, ..., v{n-1}]
+        mul                                    # stack: [v{j} * root_of_unity^(jk), v{j+1}, ..., v{n-1}]
 
         # update result
-        loc_load.4                             # load result
-        add                                    # sum previous partial result with v{j} * root_of_unity^(jk)
-        loc_store.4                            # store partial result
+        loc_load.4                             # stack: [result, v{j} * root_of_unity^(jk), v{j+1}, ..., v{n-1}]
+        add                                    # stack: [result + v{j} * root_of_unity^(jk), v{j+1}, ..., v{n-1}]
+        loc_store.4                            # stack: [v{j+1}, ..., v{n-1}]
 
-        # Stack here: [v{j+1}, ..., v{n-1}, ...]
-
-        # Update j
-        loc_load.3                             # load j
-        add.1                                  # increment j by 1
-        dup                                    # dup before store to keep j+1 on stack
-        loc_store.3                            # store j+1
+        # Increment j
+        loc_load.3                             # stack: [j, v{j+1}, ..., v{n-1}]
+        add.1                                  # stack: [j+1, v{j+1}, ..., v{n-1}]
+        dup                                    # stack: [j+1, j+1, v{j+1}, ..., v{n-1}]
+        loc_store.3                            # stack: [j+1, v{j+1}, ..., v{n-1}]
 
         # Check if we're done looping
-        loc_load.2                             # load n. stack: [n, j+1, ...]
-        neq                                     # Check if j+1 != n; if so, we continue. Else, we're done.
+        loc_load.2                             # stack: [n, j+1, v{j+1}, ..., v{n-1}]
+        neq                                    # stack: [1 or 0, v{j+1}, ..., v{n-1}]
     end
 
     # Return result
@@ -233,5 +281,8 @@ proc.main.3
 end
 
 begin
+    # TODO:
+    # fix f_k for k>0
+    # fix "unreachable" error
     exec.main
 end

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -132,10 +132,15 @@ proc.store_array
 end
 
 #! Retrieves an array previously stored with `proc.store_array`.
-#! Input: None
+#! Input: [array_loc], the memory location to retrieve the array
 #! Output: [n, v0, ..., v{n-1}]
-proc.retrieve_array
-    mem_load.ARR_LOC                          # stack: [n, ...]
+#!
+#! Locals
+#! 0: array_loc
+proc.retrieve_array.1
+    dup                                       # stack: [array_loc, array_loc, ...]
+    loc_store.0                               # stack: [array_loc, ...]
+    mem_load                                  # stack: [n, ...]
 
     # Prepare stack for loop
     push.0.1                                  # pushes i=0, followed by 1 so that we enter the loop
@@ -144,13 +149,13 @@ proc.retrieve_array
         # stack: [i, n, v{i}, ..., v{n-1}]
 
         # Setup read offset
-        # Note: we read at location `ARR_LOC + n - i`, since the element at ARR_LOC is `n`
-        # (i.e. the array starts at address `ARR_LOC + 1`)
+        # Note: we read at location `array_loc + n - i`, since the element at array_loc is `n`
+        # (i.e. the array starts at address `array_loc + 1`)
         dup.1                                   # stack: [n, i, n, v{i+1}, ..., v{n-1}]
         dup.1                                   # stack: [i, n, i, n, v{i+1}, ..., v{n-1}]
         sub                                     # stack: [n - i, i, n, v{i+1}, ..., v{n-1}]
-        push.ARR_LOC                            # stack: [ARR_LOC, n - i, i, n, v{i+1}, ..., v{n-1}]
-        add                                     # stack: [ARR_LOC + n - i, i, n, v{i+1}, ..., v{n-1}]
+        loc_load.0                              # stack: [array_loc, n - i, i, n, v{i+1}, ..., v{n-1}]
+        add                                     # stack: [array_loc + n - i, i, n, v{i+1}, ..., v{n-1}]
 
         # Read v{i} and put in its spot on the stack
         mem_load                                # stack: [v{i}, i, n, v{i+1}, ..., v{n-1}]

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -109,6 +109,7 @@ proc.store_array
 
         # Setup write offset
         # Note: we write at location i + (ARR_LOC + 1), since the element at ARR_LOC is `n`
+        # (i.e. the array starts at address `ARR_LOC + 1`)
         movup.2                               # stack: [v{i}, i, n, v{i+1}, ..., v{n-1}]
         dup.1                                 # stack: [i, v{i}, i, n, v{i+1}, ..., v{n-1}]
         push.ARR_LOC                          # stack: [ARR_LOC, i, v{i}, i, n, v{i+1}, ..., v{n-1}]
@@ -128,6 +129,43 @@ proc.store_array
     # stack: [n, n, ...]
     drop                                      # stack: [n, ...]
     drop                                      # stack: [...]
+end
+
+#! Retrieves an array previously stored with `proc.store_array`.
+#! Input: None
+#! Output: [n, v0, ..., v{n-1}]
+proc.retrieve_array
+    mem_load.ARR_LOC                          # stack: [n, ...]
+
+    # Prepare stack for loop
+    push.0.1                                  # pushes i=0, followed by 1 so that we enter the loop
+
+    while.true
+        # stack: [i, n, v{i}, ..., v{n-1}]
+
+        # Setup read offset
+        # Note: we read at location `ARR_LOC + n - i`, since the element at ARR_LOC is `n`
+        # (i.e. the array starts at address `ARR_LOC + 1`)
+        dup.1                                   # stack: [n, i, n, v{i+1}, ..., v{n-1}]
+        dup.1                                   # stack: [i, n, i, n, v{i+1}, ..., v{n-1}]
+        sub                                     # stack: [n - i, i, n, v{i+1}, ..., v{n-1}]
+        push.ARR_LOC                            # stack: [ARR_LOC, n - i, i, n, v{i+1}, ..., v{n-1}]
+        add                                     # stack: [ARR_LOC + n - i, i, n, v{i+1}, ..., v{n-1}]
+
+        # Read v{i} and put in its spot on the stack
+        mem_load                                # stack: [v{i}, i, n, v{i+1}, ..., v{n-1}]
+        movdn.2                                 # stack: [i, n, v{i}, v{i+1}, ..., v{n-1}]
+
+        # Increment i and check if we're done
+        add.1                                 # stack: [i+1, n, v{i}, v{i+1}, ..., v{n-1}]
+        dup.1                                 # stack: [n, i+1, n, v{i}, v{i+1}, ..., v{n-1}]
+        dup.1                                 # stack: [i+1, n, i+1, n, v{i}, v{i+1}, ..., v{n-1}]
+        neq                                   # stack: [1 or 0, i+1, n, v{i}, v{i+1}, ..., v{n-1}]
+    end
+
+    # stack: [n, n, v0, ..., v{n-1}]
+
+    drop                                      # stack: [n, v0, ..., v{n-1}]
 end
 
 begin

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -20,6 +20,10 @@ const.TWO_ADIC_ROOT_OF_UNITY=7277203076849721926
 # For more information about two-adicity, see https://cryptologie.net/article/559/whats-two-adicity/.
 const.TWO_ADICITY=32
 
+# Location where we will store the input array.
+# [0, 2^30) is global memory, so we store it at the beginning.
+const.ARR_LOC=0
+
 #! Computes the primitive root of unity for a subgroup of size 2^n.
 #!
 #! Input: n, the size of the input list (must be <= 32)
@@ -85,6 +89,45 @@ proc.f_k.5
 
     # Return result
     loc_load.4                                 # load result
+end
+
+# Stores an array to `ARR_LOC`, where an "array" is a list of elements prefixed by their length.
+# The array is stored in the same order, that is [n, v0, ..., v{n-1}].
+# The inverse operation is `proc.retrieve_array`.
+# Input: [n, v0, ..., v{n-1}, ...]
+# Output: [...]
+proc.store_array
+    # Store n
+    dup
+    mem_store.ARR_LOC
+
+    # Prepare stack for loop
+    push.0.1                                  # pushes i=0, followed by 1 so that we enter the loop
+
+    while.true
+        # stack: [i, n, v{i}, ..., v{n-1}]
+
+        # Setup write offset
+        # Note: we write at location i + (ARR_LOC + 1), since the element at ARR_LOC is `n`
+        movup.2                               # stack: [v{i}, i, n, v{i+1}, ..., v{n-1}]
+        dup.1                                 # stack: [i, v{i}, i, n, v{i+1}, ..., v{n-1}]
+        push.ARR_LOC                          # stack: [ARR_LOC, i, v{i}, i, n, v{i+1}, ..., v{n-1}]
+        add.1                                 # stack: [ARR_LOC+1, i, v{i}, i, n, v{i+1}, ..., v{n-1}]
+        add                                   # stack: [i+ARR_LOC+1, v{i}, i, n, v{i+1}, ..., v{n-1}]
+
+        # Write v{i}
+        mem_store                             # stack: [i, n, v{i+1}, ..., v{n-1}]
+
+        # Increment i and check if we're done
+        add.1                                 # stack: [i+1, n, v{i+1}, ..., v{n-1}]
+        dup.1                                 # stack: [n, i+1, n, v{i+1}, ..., v{n-1}]
+        dup.1                                 # stack: [i+1, n, i+1, n, v{i+1}, ..., v{n-1}]
+        neq                                   # stack: [1 or 0, i+1, n, v{i+1}, ..., v{n-1}]
+    end
+
+    # stack: [n, n, ...]
+    drop                                      # stack: [n, ...]
+    drop                                      # stack: [...]
 end
 
 begin

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -50,10 +50,8 @@ proc.f_k.5
     loc_store.0                                # store k
     loc_store.1                                # store root_of_unity
     loc_store.2                                # store n
-    push.0
-    loc_store.3                                # store j, initialized to 0
-    push.0
-    loc_store.4                                # store result, initialized to 0
+
+    # `j` and `result` are initialized to 0 by the VM
 
     # Stack here: [v0, ..., v{n-1}, ...]
 
@@ -93,7 +91,7 @@ begin
     dup                                        # duplicate n (size of the input list)
     exec.get_root_of_unity
 
-    push.0                                     # push 0
+    push.0                                     # push k=0
 
     # stack: [k=0, , root_of_unity, n, v_0, ..., v_{n-1}]
     exec.f_k

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -22,12 +22,15 @@ const.TWO_ADICITY=32
 
 # Location where we will store the input array.
 # [0, 2^30) is global memory, so we store it at the beginning.
-const.ARR_LOC=0
+const.INPUT_ARR_LOC=0
+
+# Location at 3 * 2^30, the first address "with no special meaning" in the root context
+const.RESULT_ARR_LOC=3221225472
 
 #! Computes the primitive root of unity for a subgroup of size 2^n.
 #!
-#! Input: n, the size of the input list (must be <= 32)
-#! Output: Places the primitive root of unity of order 2^n on the stack
+#! Input: [n], the size of the input list (must be <= 32)
+#! Output: [root_of_unity], where `root_of_unity` is the primitive root of unity of order 2^n
 #!
 #! Equivalent to Winterfell's implementation: 
 #! https://github.com/facebook/winterfell/blob/4543689f73a2efb9d30927535de7b4efe7e1802d/math/src/field/traits.rs#L254-L259
@@ -91,7 +94,7 @@ proc.f_k.5
     loc_load.4                                 # load result
 end
 
-# Stores an array to `ARR_LOC`, where an "array" is a list of elements prefixed by their length.
+# Stores an array to `INPUT_ARR_LOC`, where an "array" is a list of elements prefixed by their length.
 # The array is stored in the same order, that is [n, v0, ..., v{n-1}].
 # The inverse operation is `proc.retrieve_array`.
 # Input: [n, v0, ..., v{n-1}, ...]
@@ -99,7 +102,7 @@ end
 proc.store_array
     # Store n
     dup
-    mem_store.ARR_LOC
+    mem_store.INPUT_ARR_LOC
 
     # Prepare stack for loop
     push.0.1                                  # pushes i=0, followed by 1 so that we enter the loop
@@ -108,13 +111,13 @@ proc.store_array
         # stack: [i, n, v{i}, ..., v{n-1}]
 
         # Setup write offset
-        # Note: we write at location i + (ARR_LOC + 1), since the element at ARR_LOC is `n`
-        # (i.e. the array starts at address `ARR_LOC + 1`)
+        # Note: we write at location i + (INPUT_ARR_LOC + 1), since the element at INPUT_ARR_LOC is `n`
+        # (i.e. the array starts at address `INPUT_ARR_LOC + 1`)
         movup.2                               # stack: [v{i}, i, n, v{i+1}, ..., v{n-1}]
         dup.1                                 # stack: [i, v{i}, i, n, v{i+1}, ..., v{n-1}]
-        push.ARR_LOC                          # stack: [ARR_LOC, i, v{i}, i, n, v{i+1}, ..., v{n-1}]
-        add.1                                 # stack: [ARR_LOC+1, i, v{i}, i, n, v{i+1}, ..., v{n-1}]
-        add                                   # stack: [i+ARR_LOC+1, v{i}, i, n, v{i+1}, ..., v{n-1}]
+        push.INPUT_ARR_LOC                          # stack: [INPUT_ARR_LOC, i, v{i}, i, n, v{i+1}, ..., v{n-1}]
+        add.1                                 # stack: [INPUT_ARR_LOC+1, i, v{i}, i, n, v{i+1}, ..., v{n-1}]
+        add                                   # stack: [i+INPUT_ARR_LOC+1, v{i}, i, n, v{i+1}, ..., v{n-1}]
 
         # Write v{i}
         mem_store                             # stack: [i, n, v{i+1}, ..., v{n-1}]
@@ -173,12 +176,62 @@ proc.retrieve_array.1
     drop                                      # stack: [n, v0, ..., v{n-1}]
 end
 
+#! Input: [n, v0, ..., v{n-1}]
+#!
+#! Locals
+#! 0: n
+#! 1: root_of_unity
+#! 2: k
+proc.main.3
+    # Initialize memory
+    # Note: k is initialized to 0 by the VM
+    dup                                      # stack: [n, n, v0, ..., v{n-1}]
+    loc_store.0                              # stack: [n, v0, ..., v{n-1}]
+    dup                                      # stack: [n, n, v0, ..., v{n-1}]
+    mem_store.RESULT_ARR_LOC                 # stack: [n, v0, ..., v{n-1}]
+    dup                                      # stack: [n, n, v0, ..., v{n-1}]
+    exec.get_root_of_unity                   # stack: [root_of_unity, n v0, ..., v{n-1}]
+    loc_store.1                              # stack: [n, v0, ..., v{n-1}]
+    exec.store_array                         # stack: []
+
+    # Prepare stack for loop
+    push.1                                 # push 1 so that we enter the loop
+
+    while.true
+        # prepare call to `proc.f_k`
+        push.INPUT_ARR_LOC                         # stack: [INPUT_ARR_LOC]
+        exec.retrieve_array                  # stack: [n, v0, ..., v{n-1}]
+        loc_load.1                           # stack: [root_of_unity, n, v0, ..., v{n-1}]
+        loc_load.2                           # stack: [k, root_of_unity, n, v0, ..., v{n-1}]
+
+        # call `proc.f_k`
+        exec.f_k                             # stack: [f_k]
+
+        # Store `f_k` at `RESULT_ARR_LOC + k + 1`
+        push.RESULT_ARR_LOC                  # stack: [RESULT_ARR_LOC, f_k]
+        loc_load.2                           # stack: [k, RESULT_ARR_LOC, f_k]
+        add                                  # stack: [RESULT_ARR_LOC + k, f_k]
+        add.1                                # stack: [RESULT_ARR_LOC + k + 1, f_k]
+        mem_store                            # stack: []
+
+        # Load, increment k, and store 
+        loc_load.2                            # stack: [k]
+        add.1                                 # stack: [k+1]
+        dup                                   # stack: [k+1, k+1]
+        loc_store.2                           # stack: [k+1]
+
+        # Check if we're done
+        loc_load.0                            # stack: [n, k+1]
+        neq                                   # stack: [1 or 0]
+    end
+
+    # stack: []
+
+    push.RESULT_ARR_LOC                       # stack: [RESULT_ARR_LOC]
+    exec.retrieve_array                       # stack: [n, f0, ..., f{n-1}]
+    drop                                      # stack: [f0, ..., f{n-1}]
+end
+
 begin
-    dup                                        # duplicate n (size of the input list)
-    exec.get_root_of_unity
-
-    push.0                                     # push k=0
-
-    # stack: [k=0, , root_of_unity, n, v_0, ..., v_{n-1}]
-    exec.f_k
+    exec.main
 end

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -79,17 +79,17 @@ end
 
 #! Computes the primitive root of unity for a subgroup of size 2^n.
 #!
-#! Input: [n], the size of the input list (must be <= 32)
+#! Input: [log2_n], log2 of the size of the input list (must be <= 32)
 #! Output: [root_of_unity], where `root_of_unity` is the primitive root of unity of order 2^n
 #!
 #! Equivalent to Winterfell's implementation: 
 #! https://github.com/facebook/winterfell/blob/4543689f73a2efb9d30927535de7b4efe7e1802d/math/src/field/traits.rs#L254-L259
 proc.get_root_of_unity
-    push.TWO_ADIC_ROOT_OF_UNITY.TWO_ADICITY     # stack: [TWO_ADICITY, TWO_ADIC_ROOT_OF_UNITY, n]
-    movup.2                                     # stack: [n, TWO_ADICITY, TWO_ADIC_ROOT_OF_UNITY]
-    sub                                         # stack: [TWO_ADICITY - n, TWO_ADIC_ROOT_OF_UNITY]
-    pow2                                        # stack: [2^(TWO_ADICITY - n), TWO_ADIC_ROOT_OF_UNITY]
-    exp                                         # stack: [TWO_ADIC_ROOT_OF_UNITY^(2^(TWO_ADICITY - n))]
+    push.TWO_ADIC_ROOT_OF_UNITY.TWO_ADICITY     # stack: [TWO_ADICITY, TWO_ADIC_ROOT_OF_UNITY, log2_n]
+    movup.2                                     # stack: [log2_n, TWO_ADICITY, TWO_ADIC_ROOT_OF_UNITY]
+    sub                                         # stack: [TWO_ADICITY - log2_n, TWO_ADIC_ROOT_OF_UNITY]
+    pow2                                        # stack: [2^(TWO_ADICITY - log2_n), TWO_ADIC_ROOT_OF_UNITY]
+    exp                                         # stack: [TWO_ADIC_ROOT_OF_UNITY^(2^(TWO_ADICITY - log2_n))]
 end
 
 #! Computes the kth element of the "frequency domain" (i.e. of the transformed list).
@@ -238,6 +238,7 @@ proc.main.3
     dup                                      # stack: [n, n, v0, ..., v{n-1}]
     mem_store.RESULT_ARR_LOC                 # stack: [n, v0, ..., v{n-1}]
     dup                                      # stack: [n, n, v0, ..., v{n-1}]
+    exec.log2                                # stack: [log2(n), n, v0, ..., v{n-1}]
     exec.get_root_of_unity                   # stack: [root_of_unity, n v0, ..., v{n-1}]
     loc_store.1                              # stack: [n, v0, ..., v{n-1}]
     exec.store_array                         # stack: []

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -282,8 +282,5 @@ proc.main.3
 end
 
 begin
-    # TODO:
-    # fix f_k for k>0
-    # fix "unreachable" error
     exec.main
 end

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -3,6 +3,14 @@
 # This program makes use of the fact that the modulus for the Miden VM's prime field is 2^64 - 2^32 + 1.
 #
 # See the corresponding Wikipedia article: https://en.wikipedia.org/wiki/Discrete_Fourier_transform_over_a_ring
+#
+# Expects the input stack to be
+# Input: [<length of list>, <ele 0>, <ele 1>, ...]
+# 
+# Ouputs the Discrete Fourier Transform of the original list, which is a list of the same length.
+# Output: [<ele 0'>, <ele 1'>, ...]
+#
+# Convention: inputs are always consumed by the callee
 
 # Root of unity for domain of 2^32 elements, taken from Winterfell. See:
 # https://github.com/facebook/winterfell/blob/4543689f73a2efb9d30927535de7b4efe7e1802d/math/src/field/f64/mod.rs#L270
@@ -12,8 +20,10 @@ const.TWO_ADIC_ROOT_OF_UNITY=7277203076849721926
 # For more information about two-adicity, see https://cryptologie.net/article/559/whats-two-adicity/.
 const.TWO_ADICITY=32
 
-#! Input: n (must be <= 32)
-#! Output: Returns the primitive root of unity of order 2^n.
+#! Computes the primitive root of unity for a subgroup of size 2^n.
+#!
+#! Input: n, the size of the input list (must be <= 32)
+#! Output: Places the primitive root of unity of order 2^n on the stack
 #!
 #! Equivalent to Winterfell's implementation: 
 #! https://github.com/facebook/winterfell/blob/4543689f73a2efb9d30927535de7b4efe7e1802d/math/src/field/traits.rs#L254-L259
@@ -25,7 +35,66 @@ proc.get_root_of_unity
     exp                                         # stack: [TWO_ADIC_ROOT_OF_UNITY^(2^(TWO_ADICITY - n))]
 end
 
+#! Computes the kth element of the "frequency domain" (i.e. of the transformed list).
+#!
+#! Input: [k, root_of_unity, n, v_0, ..., v_{n-1}, ...]
+#! Output: [f_k, ...]
+#!
+#! Locals
+#! 0: k
+#! 1: root_of_unity
+#! 2: n (length of the list)
+#! 3: j (counter)
+#! 4: result (partial result of the computation)
+proc.f_k.5
+    loc_store.0                                # store k
+    loc_store.1                                # store root_of_unity
+    loc_store.2                                # store n
+    push.0
+    loc_store.3                                # store j, initialized to 0
+    push.0
+    loc_store.4                                # store result, initialized to 0
+
+    # Stack here: [v0, ..., v{n-1}, ...]
+
+    push.1                                     # push 1 to enter the loop
+    while.true
+        # compute `root_of_unity^(jk)`
+        loc_load.1                             # load root_of_unity
+        loc_load.0                             # load k
+        loc_load.3                             # load j
+        mul                                    # compute j*k
+        exp                                    # compute root_of_unity^(jk)
+        mul                                    # compute v{j} * root_of_unity^(jk)
+
+        # update result
+        loc_load.4                             # load result
+        add                                    # sum previous partial result with v{j} * root_of_unity^(jk)
+        loc_store.4                            # store partial result
+
+        # Stack here: [v{j+1}, ..., v{n-1}, ...]
+
+        # Update j
+        loc_load.3                             # load j
+        add.1                                  # increment j by 1
+        dup                                    # dup before store to keep j+1 on stack
+        loc_store.3                            # store j+1
+
+        # Check if we're done looping
+        loc_load.2                             # load n. stack: [n, j+1, ...]
+        neq                                     # Check if j+1 != n; if so, we continue. Else, we're done.
+    end
+
+    # Return result
+    loc_load.4                                 # load result
+end
 
 begin
+    dup                                        # duplicate n (size of the input list)
     exec.get_root_of_unity
+
+    push.0                                     # push 0
+
+    # stack: [k=0, , root_of_unity, n, v_0, ..., v_{n-1}]
+    exec.f_k
 end

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -1,0 +1,31 @@
+# A program which computes the Discrete Fourier Transform (DFT) of the provided public inputs.
+# We only allow input sizes of a power of 2 for convenience of computing the primitive root of unity.
+# This program makes use of the fact that the modulus for the Miden VM's prime field is 2^64 - 2^32 + 1.
+#
+# See the corresponding Wikipedia article: https://en.wikipedia.org/wiki/Discrete_Fourier_transform_over_a_ring
+
+# Root of unity for domain of 2^32 elements, taken from Winterfell. See:
+# https://github.com/facebook/winterfell/blob/4543689f73a2efb9d30927535de7b4efe7e1802d/math/src/field/f64/mod.rs#L270
+const.TWO_ADIC_ROOT_OF_UNITY=7277203076849721926
+
+# This means there's a multiplicative subgroup of size 2^32 that exists in the field.
+# For more information about two-adicity, see https://cryptologie.net/article/559/whats-two-adicity/.
+const.TWO_ADICITY=32
+
+#! Input: n (must be <= 32)
+#! Output: Returns the primitive root of unity of order 2^n.
+#!
+#! Equivalent to Winterfell's implementation: 
+#! https://github.com/facebook/winterfell/blob/4543689f73a2efb9d30927535de7b4efe7e1802d/math/src/field/traits.rs#L254-L259
+proc.get_root_of_unity
+    push.TWO_ADIC_ROOT_OF_UNITY.TWO_ADICITY     # stack: [TWO_ADICITY, TWO_ADIC_ROOT_OF_UNITY, n]
+    movup.2                                     # stack: [n, TWO_ADICITY, TWO_ADIC_ROOT_OF_UNITY]
+    sub                                         # stack: [TWO_ADICITY - n, TWO_ADIC_ROOT_OF_UNITY]
+    pow2                                        # stack: [2^(TWO_ADICITY - n), TWO_ADIC_ROOT_OF_UNITY]
+    exp                                         # stack: [TWO_ADIC_ROOT_OF_UNITY^(2^(TWO_ADICITY - n))]
+end
+
+
+begin
+    exec.get_root_of_unity
+end

--- a/examples/dft.masm
+++ b/examples/dft.masm
@@ -107,8 +107,10 @@ proc.f_k.5
     loc_store.0                                # store k
     loc_store.1                                # store root_of_unity
     loc_store.2                                # store n
-
-    # `j` and `result` are initialized to 0 by the VM
+    push.0                                     # Prepare j = 0
+    loc_store.3                                # Set j = 0
+    push.0                                     # Prepare result = 0
+    loc_store.4                                # Set result = 0
 
     # Stack here: [v0, ..., v{n-1}, ...]
 


### PR DESCRIPTION
Implements the [Discrete Fourier Transform](https://en.wikipedia.org/wiki/Discrete_Fourier_transform_over_a_ring) over the input list. Basically, this is the non-efficient version of the Number Theoretic Transform (NTT).

You can verify the correctness of the program by comparing with the Python implementation:

```py
# Adapted from https://www.geeksforgeeks.org/python-number-theoretic-transformation/
from sympy import ntt 
  
seq = [15, 21, 13, 44] 
  
prime_no = 2**64 - 2**32 + 1
  
# ntt 
transform = ntt(seq, prime_no) 
print ("NTT : ", transform)

# NTT :  [93, 18440270144950239235, 18446744069414584284, 6473924464345090]
```

Conceptually though, this Miden implementation is closer to

```py
from math import log2

PRIME = 2**64 - 2**32 + 1
TWO_ADIC_ROOT_OF_UNITY = 7277203076849721926

def get_root_of_unity(n):
    power = (1 << (32 - n)) % PRIME
    return pow(TWO_ADIC_ROOT_OF_UNITY, power, PRIME)

def f_k(seq, k, alpha):
    alpha_k = pow(alpha, k, PRIME)
    return sum([(seq[i] * pow(alpha_k, i, PRIME)) for i in range(len(seq))]) % PRIME

def ntt(seq, alpha):
    return [f_k(seq, k, alpha) for k in range(len(seq))]

seq = [15, 21, 13, 44]
alpha = get_root_of_unity(int(log2(len(seq))))

print(ntt(seq, alpha))
```
