### PR TITLE
changing the docs link to next (main is broken)

### DIFF
--- a/playground/src/components/Header.tsx
+++ b/playground/src/components/Header.tsx
@@ -7,7 +7,7 @@ import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 const navigation = [
   {
     name: 'Documentation',
-    href: 'https://wiki.polygon.technology/docs/miden/user_docs/assembly/main'
+    href: 'https://0xpolygonmiden.github.io/miden-vm/intro/main.html'
   },
   {
     name: 'Developer Tools',


### PR DESCRIPTION
Quick change: we need to change the docs to `next`. The playground runs at `main` Miden VM 0.7 but we won't change the assembly instructions for now and `main` isn't built atm.