### PR TITLE
adding cycles and program_hash to Outputs

### DIFF
--- a/playground/miden-wasm/src/lib.rs
+++ b/playground/miden-wasm/src/lib.rs
@@ -9,7 +9,9 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Deserialize, Serialize)]
 pub struct Outputs {
+    pub program_hash: String,
     pub stack_output: Vec<u64>,
+    pub cycles: Option<usize>,
     pub trace_len: Option<usize>,
     pub overflow_addrs: Option<Vec<u64>>,
     pub proof: Option<Vec<u8>>,
@@ -42,7 +44,9 @@ pub fn run_program(code_frontend: &str, inputs_frontend: &str) -> Result<Outputs
     .map_err(|err| format!("Failed to generate execution trace - {:?}", err))?;
 
     let result = Outputs {
+        program_hash: program.program_info.unwrap().program_hash().to_string(),
         stack_output: trace.stack_outputs().stack().to_vec(),
+        cycles: Some(trace.trace_len_summary().trace_len()),
         trace_len: Some(trace.get_trace_len()),
         overflow_addrs: None,
         proof: None,
@@ -79,7 +83,9 @@ pub fn prove_program(code_frontend: &str, inputs_frontend: &str) -> Result<Outpu
     .map_err(|err| format!("Failed to prove execution - {:?}", err))?;
 
     let result = Outputs {
+        program_hash: program.program_info.clone().unwrap().program_hash().to_string(),
         stack_output: output.stack().to_vec(),
+        cycles: None,
         trace_len: Some(proof.stark_proof().trace_length()),
         overflow_addrs: Some(output.overflow_addrs().to_vec()),
         proof: Some(proof.to_bytes()),


### PR DESCRIPTION
We add `program_hash` and `cycles` to the `Outputs` when a program runs or is proven.

We don't read the value in TypeScript-land yet, because there is a team re-writing / re-designing and they will pick it up.